### PR TITLE
Add webcam/audio support

### DIFF
--- a/src/Sandbox.wsb
+++ b/src/Sandbox.wsb
@@ -13,4 +13,6 @@
     <LogonCommand>
         <Command>powershell.exe -ExecutionPolicy Bypass -File C:\Users\wdagutilityaccount\Desktop\runtime_directory\sandbox_run.ps1</Command>
     </LogonCommand>
+    <AudioInput>Enable</AudioInput>
+    <VideoInput>Enable</VideoInput>
 </Configuration>


### PR DESCRIPTION
This PR adds support for webcam and audio, which is required for some lockdown browser tests.