### PR TITLE
Clarify version selection in `Readme.md`

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/feature-requests.yml
+++ b/.github/DISCUSSION_TEMPLATE/feature-requests.yml
@@ -19,11 +19,11 @@ body:
       description: >
         If **any** of the following apply, **do not continue with this form**; instead, [open a new issue](https://github.com/gucci-on-fleek/lockdown-browser/issues/new?template=bug-report.yml):
 
-          - You see an error message at any point (e.g., when running the build script, when launching the _Windows Sandbox_, when launching the _Lockdown Browser_, etc.).
+          - You see an error message at any point (e.g., when running the build script, launching the _Windows Sandbox_, launching the _Lockdown Browser_, etc.).
 
           - The _Lockdown Browser_ or _Windows Sandbox_ fail to open or crash.
 
-          - You get a message from the _Lockdown Browser_ stating that it's running inside a virtual machine or that it has detected any other form of tampering.
+          - You get a message from the _Lockdown Browser_ stating that it's running inside a virtual machine or has detected any other form of tampering.
 
           - Your webcam or microphone fails to work as expected.
 

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -19,11 +19,11 @@ body:
       description: >
         If **any** of the following apply, **do not continue with this form**; instead, [open a new issue](https://github.com/gucci-on-fleek/lockdown-browser/issues/new?template=bug-report.yml):
 
-          - You see an error message at any point (e.g., when running the build script, when launching the _Windows Sandbox_, when launching the _Lockdown Browser_, etc.).
+          - You see an error message at any point (e.g., when running the build script, launching the _Windows Sandbox_, launching the _Lockdown Browser_, etc.).
 
           - The _Lockdown Browser_ or _Windows Sandbox_ fail to open or crash.
 
-          - You get a message from the _Lockdown Browser_ stating that it's running inside a virtual machine or that it has detected any other form of tampering.
+          - You get a message from the _Lockdown Browser_ stating that it's running inside a virtual machine or has detected any other form of tampering.
 
           - Your webcam or microphone fails to work as expected.
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -28,7 +28,7 @@ body:
             If you get a "the setup configuration provider is not registered" error message, have you [installed the "Visual Studio C++ Tools"](https://github.com/gucci-on-fleek/lockdown-browser?tab=readme-ov-file#system-requirements)?
           required: true
         - label: >
-            You have tried rebuilding from scratch (Reset your build with `./build.ps1 -Clean`, then run ./build.ps1` to build again).
+            You have tried rebuilding from scratch (Reset your build with `./build.ps1 -Clean`, and it will reset your workspace and build.).
 
   - type: textarea
     attributes:

--- a/Readme.md
+++ b/Readme.md
@@ -72,6 +72,48 @@ Make sure to **clone** the repository and run `build.ps1`. Then, [install the _W
  (_Alternative_) If you want to pass your microphone and camera to the _Lockdown Browser_, run `Sandbox-with-Microphone-Camera.wsb` instead.
 4. Go to your test and open it. The _Lockdown Browser_ will launch, and you can then use it to complete your test.
 
+## Versions
+
+The `release` branch (default) will always point to the latest stable
+release. You should usually use this branch since it is the most
+well-tested. To switch to this branch (not generally necessary since
+it’s the default), run:
+
+```powershell
+git switch release
+```
+
+The `master` branch will always point to the latest development version.
+This branch has been tested and should _generally_ be safe to use, but
+it will often have minor issues that have not been fixed yet. You should
+use this branch if it contains a feature or fix you need that is not in
+the `release` branch, or if the `release` branch isn’t working for you
+and you’re feeling adventurous. To switch to this branch, run:
+
+```powershell
+git switch master
+```
+
+The `dev` branch contains in-progress work, is often broken, and should
+only be used if you were specifically asked to test it. To switch to
+this branch, run:
+
+```powershell
+git switch dev
+```
+
+If something isn’t working but was previously, you can always switch to
+a previous release by running:
+
+```powershell
+git switch --detach <tag>
+```
+
+where `<tag>` is the tag of the release you want to switch to. You can
+[browse the list of releases on
+GitHub](https://github.com/gucci-on-fleek/lockdown-browser/releases) in
+case you’re unsure which tag to choose.
+
 ## Common Issues
 
 ### The _Browser_ updates itself, then it stops working

--- a/Readme.md
+++ b/Readme.md
@@ -69,13 +69,13 @@ Make sure to **clone** the repository and run `build.ps1`. Then, [install the _W
 2. Download the _Respondus Lockdown Browser_ and place it in `runtime_directory\`.
 3. Double-click `Sandbox.wsb` (it’s in `runtime_directory\`)
 
- (_Alternative_) If you want to pass your microphone and camera to the _Lockdown Browser_, run `Sandbox-with-Microphone-Camera.wsb` instead.
+   (_Alternative_) If you want to pass your microphone and camera to the _Lockdown Browser_, run `Sandbox-with-Microphone-Camera.wsb` instead.
 4. Go to your test and open it. The _Lockdown Browser_ will launch, and you can then use it to complete your test.
 
 ## Versions
 
-The `release` branch (default) will always point to the latest stable
-release. You should usually use this branch since it is the most
+The `release` branch (default) always points to the latest stable
+release. You should use this branch since it is the most
 well-tested. To switch to this branch (not generally necessary since
 it’s the default), run:
 
@@ -87,8 +87,8 @@ The `master` branch will always point to the latest development version.
 This branch has been tested and should _generally_ be safe to use, but
 it will often have minor issues that have not been fixed yet. You should
 use this branch if it contains a feature or fix you need that is not in
-the `release` branch, or if the `release` branch isn’t working for you
-and you’re feeling adventurous. To switch to this branch, run:
+the `release` branch or if the `release` branch isn’t working for you
+and you’re feeling adventurous. To switch to this branch, run the following:
 
 ```powershell
 git switch master
@@ -96,7 +96,7 @@ git switch master
 
 The `dev` branch contains in-progress work, is often broken, and should
 only be used if you were specifically asked to test it. To switch to
-this branch, run:
+this branch, run the following:
 
 ```powershell
 git switch dev
@@ -109,7 +109,7 @@ a previous release by running:
 git switch --detach <tag>
 ```
 
-where `<tag>` is the tag of the release you want to switch to. You can
+Where `<tag>` is the tag of the release you want to switch to. You can
 [browse the list of releases on
 GitHub](https://github.com/gucci-on-fleek/lockdown-browser/releases) in
 case you’re unsure which tag to choose.
@@ -133,7 +133,7 @@ cd C:\Users\WDAGUtilityAccount\Desktop\runtime_directory\
 .\withdll.exe /d:GetSystemMetrics-Hook.dll "C:\Program Files (x86)\Respondus\LockDown Browser\LockDownBrowser.exe"
 ```
 
-(OEM versions of the _Lockdown Browser_ must have a URL at the end; `ldb:dh%7BKS6poDqwsi1SHVGEJ+KMYaelPZ56lqcNzohRRiV1bzFj3Hjq8lehqEug88UjowG1mK1Q8h2Rg6j8kFZQX0FdyA==%7D` is a good default)
+(OEM versions of the _Lockdown Browser_ **must** have a URL at the end; `ldb:dh%7BKS6poDqwsi1SHVGEJ+KMYaelPZ56lqcNzohRRiV1bzFj3Hjq8lehqEug88UjowG1mK1Q8h2Rg6j8kFZQX0FdyA==%7D` is a good default)
 
 Of course, this is usually symptomatic of another issue, so please ensure you have followed all the earlier instructions.
 

--- a/build.ps1
+++ b/build.ps1
@@ -240,5 +240,6 @@ try {
 }
 catch {
     Write-Log "An error occurred: $($_.Exception.Message) - $($_.Exception.StackTrace)"
+    Set-Location $PSScriptRoot  # Put you back rather than random places in the script. -Voidless7125
     throw
 }

--- a/build.ps1
+++ b/build.ps1
@@ -242,4 +242,5 @@ catch {
     Write-Log "An error occurred: $($_.Exception.Message) - $($_.Exception.StackTrace)"
     Set-Location $PSScriptRoot  # Put you back rather than random places in the script. -Voidless7125
     throw
+    pause
 }

--- a/runtime_directory/sandbox_run.ps1
+++ b/runtime_directory/sandbox_run.ps1
@@ -24,8 +24,7 @@ function Write-Log {
 
 # Check if running as WDAGUtilityAccount (Sandbox)
 if ($env:USERNAME -ne "WDAGUtilityAccount") {
-    Write-Log "This script is intended to run only in Windows Sandbox. Exiting..."
-    throw $_
+    throw "This script is intended to run only in Windows Sandbox. Exiting..."
 }
 
 Set-Location $PSScriptRoot
@@ -39,11 +38,15 @@ elseif ($lockdown_installer.Name -like "LockDownBrowser-*.exe") {
     $is_oem = $false
     $lockdown_runtime = [System.Environment]::GetFolderPath("ProgramFilesX86") + "\Respondus\LockDown Browser\LockDownBrowser.exe"
     $browser_icon = [System.Environment]::GetFolderPath("ProgramFilesX86") + "\Respondus\LockDown Browser\LockDownBrowser.ico"
+    $protocols = @("rldb")
+ 
 }
 else {
     $is_oem = $true
     $lockdown_runtime = [System.Environment]::GetFolderPath("ProgramFilesX86") + "\Respondus\LockDown Browser OEM\LockDownBrowserOEM.exe"
     $browser_icon = [System.Environment]::GetFolderPath("ProgramFilesX86") + "\Respondus\LockDown Browser OEM\LockDownBrowser.ico"
+    # I got the urls from installing LDB OEM and looking in the registry for :Lockdown Browser OEM and found all these HKCR keys.
+    $protocols = @("anst", "cllb", "ibz", "ielb", "jnld", "jzl", "ldb", "ldb1", "pcgs", "plb", "pstg", "rzi", "uwfb", "xmxg")
 }
 
 function Remove-SystemInfo {
@@ -101,17 +104,9 @@ function Install-LockdownBrowser {
 function Register-URLProtocol {
     Write-Log "Registering URL protocol(s)..."
     New-PSDrive -PSProvider registry -Root HKEY_CLASSES_ROOT -Name HKCR
-    if ($is_oem) {
-        # I got the urls from installing LDB OEM and looking in the registry for :Lockdown Browser OEM and found all these HKCR keys.
-        $protocols = @("anst", "cllb", "ibz", "ielb", "jnld", "jzl", "ldb", "ldb1", "pcgs", "plb", "pstg", "rzi", "uwfb", "xmxg")
-        foreach ($protocol in $protocols) {
-            Set-ItemProperty -Path "HKCR:\$protocol\shell\open\command" -Name "(Default)" -Value ('"' + $PSScriptRoot + '\withdll.exe" "/d:' + $PSScriptRoot + '\GetSystemMetrics-Hook.dll" ' + $lockdown_runtime + ' "%1"')
-            Write-Log "Successfully set item property for URL protocol $protocol."
-        }
-    }
-    else {
-        Set-ItemProperty -Path "HKCR:\rldb\shell\open\command" -Name "(Default)" -Value ('"' + $PSScriptRoot + '\withdll.exe" "/d:' + $PSScriptRoot + '\GetSystemMetrics-Hook.dll" ' + $lockdown_runtime + ' "%1"')
-        Write-Log "Successfully set item property for URL protocol rldb."
+    foreach ($protocol in $protocols) {
+        Set-ItemProperty -Path "HKCR:\$protocol\shell\open\command" -Name "(Default)" -Value ('"' + $PSScriptRoot + '\withdll.exe" "/d:' + $PSScriptRoot + '\GetSystemMetrics-Hook.dll" ' + $lockdown_runtime + ' "%1"')
+        Write-Log "Successfully set item property for URL protocol $protocol."
     }
 }
 

--- a/runtime_directory/sandbox_run.ps1
+++ b/runtime_directory/sandbox_run.ps1
@@ -25,6 +25,7 @@ function Write-Log {
 # Check if running as WDAGUtilityAccount (Sandbox)
 if ($env:USERNAME -ne "WDAGUtilityAccount") {
     throw "This script is intended to run only in Windows Sandbox. Exiting..."
+    pause
 }
 
 Set-Location $PSScriptRoot
@@ -41,7 +42,7 @@ elseif ($lockdown_installer.Name -like "LockDownBrowser-*.exe") {
     $lockdown_runtime = [System.Environment]::GetFolderPath("ProgramFilesX86") + "\Respondus\LockDown Browser\LockDownBrowser.exe"
     $browser_icon = [System.Environment]::GetFolderPath("ProgramFilesX86") + "\Respondus\LockDown Browser\LockDownBrowser.ico"
     $protocols = @("rldb")
- 
+
 }
 else {
     $is_oem = $true

--- a/runtime_directory/sandbox_run.ps1
+++ b/runtime_directory/sandbox_run.ps1
@@ -32,6 +32,8 @@ Set-Location $PSScriptRoot
 $lockdown_extract_dir = "C:\Windows\Temp\Lockdown"
 $lockdown_installer = Get-ChildItem *LockDown*.exe | Select-Object -First 1
 if (-not $lockdown_installer) {
+    Write-Log "No Lockdown installer found in the current directory."
+    [System.Windows.Forms.MessageBox]::Show("No Lockdown installer found in the current directory. This has been logged into the logs folder on the host.", "Error", [System.Windows.Forms.MessageBoxButtons]::OK, [System.Windows.Forms.MessageBoxIcon]::Error)
     throw "No Lockdown installer found in the current directory. Exiting..."
 }
 elseif ($lockdown_installer.Name -like "LockDownBrowser-*.exe") {


### PR DESCRIPTION
Because we use Git submodules, you can't install/build this repo by downloading an archive from the GitHub releases page. And most people clones the repository are just going to use whatever `git clone <...>` gives them, which is `master` here. But since `master` is somewhat unstable, we get the problem where everyone is essentially using the unstable versions.

To solve this, we can add a new branch `release` that only contains non-release-candidate tags and set it as the default. That way, users will only get stable versions by default. The possible downside to this though is that if we default to `release`, no one will ever test `master`, so we might be really no better off than before.

Any thoughts? If you think that this is a bad idea, then let me know and we won't do it.

(Also, FYI @Voidless7125, you should have permissions to push to any branch _not_ named `master` or `release`, so feel free to push your PRs to the `dev` branch here. This would make it slightly easier for users to test potential fixes, since then you only need to use `git switch dev` instead of doing a complicated `git remote add <...>` thing. Or feel free to keep using your personal fork if that works better for you, since this is a rather trivial advantage.)